### PR TITLE
Add scope to defaults

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,9 @@ lang: en
 direction: ltr
 
 defaults:
-  - values:
+  - scope:
+      path: ""
+    values:
       lang: en
       layout: default
   - scope:


### PR DESCRIPTION
It looks like one of your defaults was missing a `scope`. If you would like to apply this to all pages/posts in your site, you could use `path: ""`.

For reference, please see: https://learn.siteleaf.com/content/defaults/

With this change, your site should sync to Siteleaf without issues.